### PR TITLE
Usage of YouTube Data API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ to [Semantic Versioning][semver].
 
 ## Unreleased
 
+- Telegram bot implementation.
+- Using of YouTube Data API, videos' list.
+
 [keepachangelog]: https://keepachangelog.com/en/1.1.0/
 
 [semver]: https://semver.org/spec/v2.0.0.html

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
       <plugin>
         <artifactId>function-maven-plugin</artifactId>
         <configuration>
-          <functionTarget>io.github.vitalijr2.ytimebot.TelegramBotFunction</functionTarget>
+          <functionTarget>io.github.vitalijr2.ytimebot.telegram.TelegramBotFunction</functionTarget>
         </configuration>
         <groupId>com.google.cloud.functions</groupId>
         <version>0.11.0</version>

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,15 @@
 # YouTube Time Bot (ytimebot), Google Cloud Function
 
+Create a photo message from a link to a YouTube video with a preview and the ability to set the
+start of the viewing. You can also replace a localized title with your own description.
+
+Send the bot a link via a regular or inline message and get the result. If you add time
+after the link, it will set the beginning of the viewing. Any other text that follows the link
+will be used as your own title for the video.
+
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/7e488e0a7b434d30a91c4d9cdfaa8328)](https://app.codacy.com/gh/vitalijr2/google-cloud-ytimebot/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![Codacy Coverage](https://app.codacy.com/project/badge/Coverage/7e488e0a7b434d30a91c4d9cdfaa8328)](https://app.codacy.com/gh/vitalijr2/google-cloud-ytimebot/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
-[![Java Version](https://img.shields.io/static/v1?label=java&message=11&color=blue&logo=java&logoColor=E23D28)](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
+[![Java Version](https://img.shields.io/static/v1?label=java&message=17&color=blue&logo=java&logoColor=E23D28)](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)
 
 ## License
 

--- a/src/main/java/io/github/vitalijr2/ytimebot/telegram/BotTools.java
+++ b/src/main/java/io/github/vitalijr2/ytimebot/telegram/BotTools.java
@@ -1,4 +1,4 @@
-package io.github.vitalijr2.ytimebot;
+package io.github.vitalijr2.ytimebot.telegram;
 
 import static java.util.Objects.nonNull;
 
@@ -50,7 +50,7 @@ class BotTools {
     try {
       httpResponse.setStatusCode(statusCode, statusMessage);
       httpResponse.appendHeader(SERVER_HEADER, FULL_VERSION_STRING);
-      if (nonNull(body)) {
+      if (null != body) {
         httpResponse.getWriter().write(body);
       }
     } catch (IOException exception) {

--- a/src/main/java/io/github/vitalijr2/ytimebot/telegram/TelegramBotFunction.java
+++ b/src/main/java/io/github/vitalijr2/ytimebot/telegram/TelegramBotFunction.java
@@ -1,12 +1,12 @@
-package io.github.vitalijr2.ytimebot;
+package io.github.vitalijr2.ytimebot.telegram;
 
-import static io.github.vitalijr2.ytimebot.BotTools.badMethod;
-import static io.github.vitalijr2.ytimebot.BotTools.internalError;
-import static io.github.vitalijr2.ytimebot.BotTools.isInlineQuery;
-import static io.github.vitalijr2.ytimebot.BotTools.isMessage;
-import static io.github.vitalijr2.ytimebot.BotTools.ok;
-import static io.github.vitalijr2.ytimebot.BotTools.okWithBody;
-import static io.github.vitalijr2.ytimebot.BotTools.viaBot;
+import static io.github.vitalijr2.ytimebot.telegram.BotTools.badMethod;
+import static io.github.vitalijr2.ytimebot.telegram.BotTools.internalError;
+import static io.github.vitalijr2.ytimebot.telegram.BotTools.isInlineQuery;
+import static io.github.vitalijr2.ytimebot.telegram.BotTools.isMessage;
+import static io.github.vitalijr2.ytimebot.telegram.BotTools.ok;
+import static io.github.vitalijr2.ytimebot.telegram.BotTools.okWithBody;
+import static io.github.vitalijr2.ytimebot.telegram.BotTools.viaBot;
 
 import com.google.cloud.functions.HttpFunction;
 import com.google.cloud.functions.HttpRequest;
@@ -23,12 +23,25 @@ import org.json.JSONTokener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Create a photo message from a link to a YouTube video with a preview and the ability to set the
+ * start of the viewing. You can also replace the localized video title with your own description.
+ */
 public class TelegramBotFunction implements HttpFunction {
 
   private static final String HTTP_POST_METHOD = "POST";
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
+  /**
+   * Get request body and send response back.
+   *
+   * @param httpRequest  Telegram update
+   * @param httpResponse Telegram webhook answer
+   * @see <a href="https://core.telegram.org/bots/api#update">Telegram Bot API: Update</a>
+   * @see <a href="https://core.telegram.org/bots/api#making-requests-when-getting-updates">Telegram
+   * Bot API: Making requests when getting updates</a>
+   */
   @Override
   public void service(HttpRequest httpRequest, HttpResponse httpResponse) {
     if (HTTP_POST_METHOD.equals(httpRequest.getMethod())) {
@@ -46,6 +59,13 @@ public class TelegramBotFunction implements HttpFunction {
     }
   }
 
+  /**
+   * If the Telegram update is a regular message or an inline query, pass it to the appropriate
+   * method: {@link #processInlineQuery(JSONObject)} or {@link #processMessage(JSONObject)}.
+   *
+   * @param requestBodyReader request body
+   * @return webhook answer if available
+   */
   @VisibleForTesting
   @NotNull
   Optional<String> processRequestBody(Reader requestBodyReader) {

--- a/src/main/java/io/github/vitalijr2/ytimebot/youtube/KeyInterceptor.java
+++ b/src/main/java/io/github/vitalijr2/ytimebot/youtube/KeyInterceptor.java
@@ -3,7 +3,13 @@ package io.github.vitalijr2.ytimebot.youtube;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 
-public class KeyInterceptor implements RequestInterceptor {
+/**
+ * Add API key to query parameters.
+ *
+ * @see <a href="https://developers.google.com/youtube/registering_an_application">Obtaining
+ * authorization credentials</a>
+ */
+class KeyInterceptor implements RequestInterceptor {
 
   private static final String KEY = "key";
 

--- a/src/main/java/io/github/vitalijr2/ytimebot/youtube/VideoData.java
+++ b/src/main/java/io/github/vitalijr2/ytimebot/youtube/VideoData.java
@@ -1,16 +1,100 @@
 package io.github.vitalijr2.ytimebot.youtube;
 
-public record VideoData(String title, String description, String channelTitle, String thumbnail,
-                        String preview, String uploadStatus, String privacyStatus,
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.regex.Pattern;
+
+/**
+ * Combination of properties of snippet and status.
+ *
+ * @param title         localized or original title
+ * @param description   localized or original description
+ * @param channelTitle  channel title
+ * @param thumbnail     default image: URL, height and width
+ * @param preview       standard image: URL, height and width
+ * @param uploadStatus  upload status
+ * @param privacyStatus privacy status
+ * @param errorReason   error reason code, see <em>Error detail</em> on <a
+ *                      href="https://developers.google.com/youtube/v3/docs/videos/list#errors">YouTube
+ *                      Data API Reference: Video list, Errors</a> and <a
+ *                      href="https://developers.google.com/youtube/v3/docs/errors#general-errors">YouTube
+ *                      Data API Reference: General errors</a>
+ * @see <a href="https://developers.google.com/youtube/v3/docs/videos/list#response">YouTube Data
+ * API Reference: Video list, Response</a>
+ * @see <a href="https://any-api.com/googleapis_com/youtube/docs/videos/youtube_videos_list">Any
+ * API: YouTube Data, Video list</a>
+ */
+public record VideoData(String title, String description, String channelTitle, Thumbnail thumbnail,
+                        Thumbnail preview, UploadStatus uploadStatus, PrivacyStatus privacyStatus,
                         String errorReason) {
 
-  public VideoData(String title, String description, String channelTitle, String thumbnail,
-      String preview, String uploadStatus, String privacyStatus) {
+  public VideoData(String title, String description, String channelTitle, Thumbnail thumbnail,
+      Thumbnail preview, UploadStatus uploadStatus, PrivacyStatus privacyStatus) {
     this(title, description, channelTitle, thumbnail, preview, uploadStatus, privacyStatus, null);
   }
 
   public VideoData(String errorReason) {
     this(null, null, null, null, null, null, null, errorReason);
+  }
+
+  /**
+   * Privacy status.
+   */
+  public enum PrivacyStatus {
+
+    Private, Public, Unlisted, UnlistedNew;
+
+    static PrivacyStatus fromString(String status) {
+      if (null == status || status.isBlank()) {
+        return null;
+      }
+
+      try {
+        return PrivacyStatus.valueOf(
+            Pattern.compile("\\b.").matcher(status.trim().toLowerCase().replaceAll("_", " "))
+                .replaceAll(m -> m.group().toUpperCase()).replaceAll("\\s", ""));
+      } catch (IllegalArgumentException exception) {
+        getLogger(PrivacyStatus.class).warn("Unknown status: {}", status);
+
+        return null;
+      }
+    }
+
+  }
+
+  /**
+   * Upload status.
+   */
+  public enum UploadStatus {
+
+    Deleted, Failed, Processed, Rejected, Uploaded;
+
+    static UploadStatus fromString(String status) {
+      if (null == status || status.isBlank()) {
+        return null;
+      }
+
+      try {
+        return UploadStatus.valueOf(Pattern.compile("^.").matcher(status.trim().toLowerCase())
+            .replaceFirst(m -> m.group().toUpperCase()));
+      } catch (IllegalArgumentException exception) {
+        getLogger(UploadStatus.class).warn("Unknown status: {}", status);
+
+        return null;
+      }
+    }
+
+  }
+
+  /**
+   * Thumbnail.
+   *
+   * @param url image URL
+   * @param height height of the thumbnail image, optional
+   * @param width width of the thumbnail image, optional
+   */
+  public record Thumbnail(String url, Integer height, Integer width) {
+
   }
 
 }

--- a/src/main/java/io/github/vitalijr2/ytimebot/youtube/VideoParameters.java
+++ b/src/main/java/io/github/vitalijr2/ytimebot/youtube/VideoParameters.java
@@ -1,19 +1,109 @@
 package io.github.vitalijr2.ytimebot.youtube;
 
-import static java.util.Objects.isNull;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
-import java.util.List;
-
-public record VideoParameters(String hl, String id, List<String> part) {
+/**
+ * Request parameters: hl, video id, parts.
+ *
+ * @param id   video ID
+ * @param hl   host language
+ * @param part list of parts, defaults to {@code snippet} and {@code status}
+ * @see <a href="https://developers.google.com/youtube/v3/docs/videos/list#parameters">YouTube Data
+ * API Reference: Video list, Parameters</a>
+ * @see <a href="https://developers.google.com/youtube/v3/docs/videos/list">YouTube Data API
+ * Reference: Video list</a>
+ */
+public record VideoParameters(String id, HostLanguage hl, PartNames... part) {
 
   public VideoParameters {
-    if (isNull(part)) {
-      part = List.of("snippet", "status");
+    if (0 == part.length) {
+      part = new PartNames[]{PartNames.Snippet, PartNames.Status};
     }
   }
 
-  public VideoParameters(String hl, String id) {
-    this(hl, id, null);
+  /**
+   * Google host language {@code hl}.
+   *
+   * @see <a
+   * href="https://developers.google.com/custom-search/docs/xml_results_appendices#interfaceLanguages">
+   * Programmable Search Engine Guide: Supported Interface Languages</a>
+   */
+  public enum HostLanguage {
+
+    Afrikaans("af"), Albanian("sq"), Amharic("am"), Arabic("ar"), Armenian("hy"), Azerbaijani(
+        "az"), Bengali("bn"), Bulgarian("bg"), Burmese("my"), Catalan("ca"), Chinese(
+        "zh"), ChineseSimplified("zh-CN"), ChineseTraditional("zh-TW"), Croatian("hr"), Czech(
+        "cs"), Danish("da"), Dutch("nl"), English("en"), EnglishUK("en-GB"), Estonian(
+        "et"), Filipino("fil"), Finnish("fi"), French("fr"), FrenchCanadian("fr-CA"), Georgian(
+        "ka"), German("de"), Greek("el"), Gujarati("gu"), Hebrew("iw"), Hindi("hi"), Hungarian(
+        "hu"), Icelandic("is"), Indonesian("id"), Italian("it"), Japanese("ja"), Kannada(
+        "kn"), Kazakh("kk"), Khmer("km"), Korean("ko"), Kyrgyz("ky"), Laothian("lo"), Latvian(
+        "lv"), Lithuanian("lt"), Macedonian("mk"), Malay("ms"), Malayam("ml"), Marathi(
+        "mr"), Mongolian("mn"), Nepali("Nepali"), Norwegian("no"), Persian("fa"), Polish(
+        "pl"), Portuguese("pt"), PortugueseBrazil("pt-BR"), PortuguesePortugal("pt-PT"), Punjabi(
+        "pa"), Romanian("ro"), Russian("ru"), Serbian("sr"), SerbianLatin("sr-Latn"), Sinhalese(
+        "si"), Slovak("sk"), Slovenian("sl"), Spanish("es"), SpanishLatinAmerica("es-419"), Swahili(
+        "sw"), Swedish("sv"), Tamil("ta"), Telugu("te"), Thai("th"), Turkish("tr"), Ukrainian(
+        "uk"), Urdu("ur"), Uzbek("uz"), Vietnamese("vi"), Welsh("cy");
+
+
+    private static final Map<String, HostLanguage> REVERSE_LOOKUP_MAP = Arrays.stream(values())
+        .collect(Collectors.toMap(value -> value.toString().toLowerCase(), Function.identity()));
+    final String hl;
+
+    HostLanguage(String hl) {
+      this.hl = hl;
+    }
+
+    static HostLanguage lookup(String hl) {
+      HostLanguage result = null;
+
+      if (null != hl) {
+        result = REVERSE_LOOKUP_MAP.get(hl.trim().toLowerCase());
+
+        if (null == result && hl.contains("-")) {
+          result = lookup(hl.split("-")[0]);
+        }
+      }
+
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return hl;
+    }
+
+  }
+
+  /**
+   * Part names
+   *
+   * @see <a href="https://developers.google.com/youtube/v3/docs/videos/list#parameters">YouTube
+   * Data API Reference: Video list, Parameters</a>
+   */
+  public enum PartNames {
+
+    ContentDetails("contentDetails"), FileDetails("fileDetails"), Identifier(
+        "id"), LiveStreamingDetails("liveStreamingDetails"), Localizations("localizations"), Player(
+        "player"), ProcessingDetails("processingDetails"), RecordingDetails(
+        "recordingDetails"), Snippet("snippet"), Statistics("statistics"), Status(
+        "status"), Suggestions("suggestions"), TopicDetails("topicDetails");
+
+    final String part;
+
+    PartNames(String part) {
+      this.part = part;
+    }
+
+    @Override
+    public String toString() {
+      return part;
+    }
+
   }
 
 }

--- a/src/main/java/io/github/vitalijr2/ytimebot/youtube/YouTubeData.java
+++ b/src/main/java/io/github/vitalijr2/ytimebot/youtube/YouTubeData.java
@@ -5,9 +5,22 @@ import feign.QueryMap;
 import feign.RequestLine;
 import org.json.JSONObject;
 
+/**
+ * YouTube Data API
+ *
+ * @see <a href="https://developers.google.com/youtube/v3">YouTube Data API</a>
+ */
 @Headers({"Accept: application/json"})
-public interface YouTubeData {
+interface YouTubeData {
 
+  /**
+   * Get video list.
+   *
+   * @param videoParameters request parameters
+   * @return video data
+   * @see <a href="https://developers.google.com/youtube/v3/docs/videos/list">YouTube Data API:
+   * Video list</a>
+   */
   @RequestLine("GET /youtube/v3/videos")
   JSONObject videos(@QueryMap VideoParameters videoParameters);
 

--- a/src/test/java/io/github/vitalijr2/ytimebot/telegram/BotToolsTest.java
+++ b/src/test/java/io/github/vitalijr2/ytimebot/telegram/BotToolsTest.java
@@ -1,4 +1,4 @@
-package io.github.vitalijr2.ytimebot;
+package io.github.vitalijr2.ytimebot.telegram;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/io/github/vitalijr2/ytimebot/telegram/TelegramBotFunctionFastTest.java
+++ b/src/test/java/io/github/vitalijr2/ytimebot/telegram/TelegramBotFunctionFastTest.java
@@ -1,4 +1,4 @@
-package io.github.vitalijr2.ytimebot;
+package io.github.vitalijr2.ytimebot.telegram;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/src/test/java/io/github/vitalijr2/ytimebot/telegram/TelegramBotFunctionSlowTest.java
+++ b/src/test/java/io/github/vitalijr2/ytimebot/telegram/TelegramBotFunctionSlowTest.java
@@ -1,6 +1,5 @@
-package io.github.vitalijr2.ytimebot;
+package io.github.vitalijr2.ytimebot.telegram;
 
-import static java.util.Objects.nonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
@@ -66,11 +65,11 @@ class TelegramBotFunctionSlowTest {
 
     when(httpRequest.getMethod()).thenReturn("POST");
     when(httpRequest.getReader()).thenReturn(new BufferedReader(reader));
-    if (nonNull(messageResponseBody)) {
+    if (null != messageResponseBody) {
       when(httpResponse.getWriter()).thenReturn(writer);
       doReturn(messageResponseBody).when(bot).processMessage(isA(JSONObject.class));
     }
-    if (nonNull(inlineQueryResponseBody)) {
+    if (null != inlineQueryResponseBody) {
       when(httpResponse.getWriter()).thenReturn(writer);
       doReturn(inlineQueryResponseBody).when(bot).processInlineQuery(isA(JSONObject.class));
     }
@@ -81,7 +80,7 @@ class TelegramBotFunctionSlowTest {
     // then
     verify(httpResponse).setStatusCode(200, "OK");
     verify(httpResponse).appendHeader(eq("Server"), anyString());
-    if (nonNull(messageResponseBody) || nonNull(inlineQueryResponseBody)) {
+    if (null != messageResponseBody || null != inlineQueryResponseBody) {
       verify(httpResponse).getWriter();
       verify(writer).write(anyString());
     }

--- a/src/test/java/io/github/vitalijr2/ytimebot/youtube/VideoDataTest.java
+++ b/src/test/java/io/github/vitalijr2/ytimebot/youtube/VideoDataTest.java
@@ -1,33 +1,51 @@
 package io.github.vitalijr2.ytimebot.youtube;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.verify;
 
+import io.github.vitalijr2.ytimebot.youtube.VideoData.PrivacyStatus;
+import io.github.vitalijr2.ytimebot.youtube.VideoData.Thumbnail;
+import io.github.vitalijr2.ytimebot.youtube.VideoData.UploadStatus;
 import java.net.MalformedURLException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
+@ExtendWith(MockitoExtension.class)
 @Tag("fast")
 class VideoDataTest {
+
+  @Mock
+  private Thumbnail preview;
+  @Mock
+  private Thumbnail thumbnail;
 
   @DisplayName("Good data")
   @Test
   void goodData() throws MalformedURLException {
     // when
-    var goodData = new VideoData("test title", "test description", "test channel title",
-        "http://thumbnail.test/path.jpg", "http://preview.test/path.jpg", "processed", "public");
+    var goodData = new VideoData("test title", "test description", "test channel title", thumbnail,
+        preview, UploadStatus.Processed, PrivacyStatus.Public);
 
     // then
     assertAll("Good video data", () -> assertNull(goodData.errorReason(), "error reason"),
         () -> assertEquals("test channel title", goodData.channelTitle(), "channel title"),
         () -> assertEquals("test description", goodData.description(), "description"),
-        () -> assertEquals("http://preview.test/path.jpg", goodData.preview(), "preview"),
-        () -> assertEquals("public", goodData.privacyStatus(), "privacy status"),
-        () -> assertEquals("http://thumbnail.test/path.jpg", goodData.thumbnail(), "thumbnail"),
+        () -> assertEquals(preview, goodData.preview(), "preview"),
+        () -> assertEquals(PrivacyStatus.Public, goodData.privacyStatus(), "privacy status"),
+        () -> assertEquals(thumbnail, goodData.thumbnail(), "thumbnail"),
         () -> assertEquals("test title", goodData.title(), "title"),
-        () -> assertEquals("processed", goodData.uploadStatus(), "upload status"));
+        () -> assertEquals(UploadStatus.Processed, goodData.uploadStatus(), "upload status"));
   }
 
   @DisplayName("Error")
@@ -44,6 +62,71 @@ class VideoDataTest {
         () -> assertNull(error.thumbnail(), "thumbnail"), () -> assertNull(error.title(), "title"),
         () -> assertNull(error.uploadStatus(), "upload status"),
         () -> assertEquals("test error reason", error.errorReason(), "error reason"));
+  }
+
+  @DisplayName("Privacy statuses")
+  @ParameterizedTest(name = "<{0}>")
+  @CsvSource(value = {"N/A,N/A", ",N/A", "   ,N/A", "Unknown,N/A", "  private ,Private",
+      "public,Public", "UNLISTED,Unlisted",
+      "unlisted_new,UnlistedNew"}, nullValues = "N/A", ignoreLeadingAndTrailingWhitespace = false)
+  void privacyStatuses(String caseInsensitiveNameOfStatus, PrivacyStatus expectedStatus) {
+    // when
+    var privacyStatus = assertDoesNotThrow(
+        () -> PrivacyStatus.fromString(caseInsensitiveNameOfStatus));
+
+    // then
+    if (null != expectedStatus) {
+      assertEquals(expectedStatus, privacyStatus);
+    } else {
+      assertNull(privacyStatus);
+    }
+
+  }
+
+  @DisplayName("Unknown privacy status")
+  @Test
+  void unknownPrivacyStatus() {
+    // given
+    var logger = LoggerFactory.getLogger(PrivacyStatus.class);
+
+    clearInvocations(logger);
+
+    // when and then
+    assertNull(assertDoesNotThrow(() -> PrivacyStatus.fromString("Unknown")));
+
+    verify(logger).warn("Unknown status: {}", "Unknown");
+  }
+
+  @DisplayName("Upload statuses")
+  @ParameterizedTest(name = "<{0}>")
+  @CsvSource(value = {"N/A,N/A", ",N/A", "   ,N/A", "  deleted ,Deleted", "failed,Failed",
+      "PROCESSED,Processed", "ReJeCTeD,Rejected",
+      "upLoaded,Uploaded"}, nullValues = "N/A", ignoreLeadingAndTrailingWhitespace = false)
+  void uploadStatuses(String caseInsensitiveNameOfStatus, UploadStatus expectedStatus) {
+    // when
+    var uploadStatus = assertDoesNotThrow(
+        () -> UploadStatus.fromString(caseInsensitiveNameOfStatus));
+
+    // then
+    if (null != expectedStatus) {
+      assertEquals(expectedStatus, uploadStatus);
+    } else {
+      assertNull(uploadStatus);
+    }
+  }
+
+  @DisplayName("Unknown upload status")
+  @Test
+  void unknownUploadStatus() {
+    // given
+    var logger = LoggerFactory.getLogger(UploadStatus.class);
+
+    clearInvocations(logger);
+
+    // when and then
+    assertNull(assertDoesNotThrow(() -> UploadStatus.fromString("Unknown")));
+
+    verify(logger).warn("Unknown status: {}", "Unknown");
   }
 
 }

--- a/src/test/java/io/github/vitalijr2/ytimebot/youtube/VideoParametersTest.java
+++ b/src/test/java/io/github/vitalijr2/ytimebot/youtube/VideoParametersTest.java
@@ -1,15 +1,20 @@
 package io.github.vitalijr2.ytimebot.youtube;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hamcrest.collection.IsArray.array;
+import static org.hamcrest.object.HasToString.hasToString;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.util.List;
+import io.github.vitalijr2.ytimebot.youtube.VideoParameters.HostLanguage;
+import io.github.vitalijr2.ytimebot.youtube.VideoParameters.PartNames;
+import java.util.Arrays;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @Tag("fast")
 class VideoParametersTest {
@@ -18,24 +23,52 @@ class VideoParametersTest {
   @Test
   void defaultParts() {
     // when
-    var videoParameters = new VideoParameters("pl", "8nKt3LOx7nA");
+    var videoParameters = new VideoParameters("8nKt3LOx7nA", HostLanguage.Polish);
 
     // then
-    assertAll("Video parameters", () -> assertEquals("pl", videoParameters.hl()),
+    assertAll("Video parameters", () -> assertThat(videoParameters.hl(), hasToString("pl")),
         () -> assertEquals("8nKt3LOx7nA", videoParameters.id()),
-        () -> assertThat(videoParameters.part(), containsInAnyOrder("status", "snippet")));
+        () -> assertThat(videoParameters.part(),
+            array(hasToString("snippet"), hasToString("status"))));
   }
 
   @DisplayName("Regular parts")
   @Test
   void regularParts() {
     // when
-    var videoParameters = new VideoParameters("pl", "8nKt3LOx7nA", List.of("test"));
+    var videoParameters = new VideoParameters("8nKt3LOx7nA", HostLanguage.Romanian,
+        PartNames.Identifier);
 
     // then
-    assertAll("Video parameters", () -> assertEquals("pl", videoParameters.hl()),
+    assertAll("Video parameters", () -> assertThat(videoParameters.hl(), hasToString("ro")),
         () -> assertEquals("8nKt3LOx7nA", videoParameters.id()),
-        () -> assertThat(videoParameters.part(), contains("test")));
+        () -> assertThat(videoParameters.part(), array(hasToString("id"))));
+  }
+
+  @DisplayName("Lookup a host language")
+  @ParameterizedTest(name = "{0}: {1}")
+  @CsvSource(value = {"en-CA,English", " en ,English", "en-GB,EnglishUK", "en-gb,EnglishUK",
+      "pl,Polish", "ro,Romanian", "xx,N/A",
+      "N/A,N/A"}, nullValues = "N/A", ignoreLeadingAndTrailingWhitespace = false)
+  void lookupHostLanguage(String hl, HostLanguage expectedValue) {
+    // when
+    var hostLanguage = HostLanguage.lookup(hl);
+
+    // then
+    if (null == expectedValue) {
+      assertNull(hostLanguage);
+    } else {
+      assertEquals(expectedValue, hostLanguage);
+    }
+  }
+
+  @DisplayName("Host languages: 74 + Chinese and Portuguese")
+  @Test
+  void hostLanguages() {
+    // when and then
+    assertAll("Host languages", () -> assertEquals(74 + 2, HostLanguage.values().length, "length"),
+        () -> Arrays.stream(HostLanguage.values())
+            .forEach(value -> assertEquals(value, HostLanguage.lookup(value.hl), "lookupable")));
   }
 
 }

--- a/src/test/java/io/github/vitalijr2/ytimebot/youtube/YouTubeTimeServiceFastTest.java
+++ b/src/test/java/io/github/vitalijr2/ytimebot/youtube/YouTubeTimeServiceFastTest.java
@@ -136,7 +136,7 @@ class YouTubeTimeServiceFastTest {
     var locatorException = assertThrows(IllegalArgumentException.class,
         () -> new YouTubeTimeService(value, "qwerty-xyz"));
     var keyException = assertThrows(IllegalArgumentException.class,
-        () -> new YouTubeTimeService("http://api.youtube.test", value));
+        () -> new YouTubeTimeService(value));
 
     // then
     assertAll("Argument exception",

--- a/src/test/resources/thumbnails_without_size.json
+++ b/src/test/resources/thumbnails_without_size.json
@@ -1,0 +1,44 @@
+{
+  "items": [
+    {
+      "snippet": {
+        "title": "Original title",
+        "description": "Original description",
+        "thumbnails": {
+          "default": {
+            "url": "https://i.ytimg.com/vi/qwerty/default.jpg"
+          },
+          "medium": {
+            "url": "https://i.ytimg.com/vi/qwerty/mqdefault.jpg",
+            "width": 320,
+            "height": 180
+          },
+          "high": {
+            "url": "https://i.ytimg.com/vi/qwerty/hqdefault.jpg",
+            "width": 480,
+            "height": 360
+          },
+          "standard": {
+            "url": "https://i.ytimg.com/vi/qwerty/sddefault.jpg",
+            "width": null,
+            "height": null
+          },
+          "maxres": {
+            "url": "https://i.ytimg.com/vi/qwerty/maxresdefault.jpg",
+            "width": 1280,
+            "height": 720
+          }
+        },
+        "channelTitle": "Channel title"
+      },
+      "status": {
+        "uploadStatus": "processed",
+        "privacyStatus": "public"
+      }
+    }
+  ],
+  "pageInfo": {
+    "totalResults": 1,
+    "resultsPerPage": 1
+  }
+}


### PR DESCRIPTION
* Replace string parameters by enums: host language and part

* Fix style issue

* Move Telegram related classes to new package

* Replace privacy and upload statuses: strings -> enums

* Replace image urls with thumbnail beans

* Add javadoc to YouTube beans and service

* Add javadoc to the bot handler. Update README.